### PR TITLE
Add autostop

### DIFF
--- a/amrclaw/2d/lib/amr2ez.f
+++ b/amrclaw/2d/lib/amr2ez.f
@@ -81,11 +81,6 @@ c
       character * 25 fname
       logical            vtime,rest
 
-      logical            amidoneyet
-      double precision   globmaxmom
-
-      common /amidone/ amidoneyet,globmaxmom
-
       dimension          tout(maxout)
       dimension          tchk(maxout)
 
@@ -112,7 +107,7 @@ c
       open(dbugunit,file=dbugfile,status='unknown',form='formatted')
       open(parmunit,file=parmfile,status='unknown',form='formatted')
 c
-c     ## New in 4.4:  
+c     ## New in 4.4:
 c     ## Open file and skip over leading lines with # comments:
       fname = 'amr2ez.data'
       call opendatafile(inunit,fname)
@@ -151,7 +146,7 @@ c         # ratios in x,y,t from next three lines:
              kratio(i)  = intratx(i)
           enddo
       endif
-          
+
 c      if (intrat(1) .lt. 0) then
 c          # this flags the situation where we do not want to refine in t
 c           write(6,*) '*** No refinement in time!'
@@ -504,15 +499,12 @@ c
      *       ' refinement ratios       ',6i5,/,/)
 119   format(' no. auxiliary vars.     ',i9)
 129   format('       var ',i5,' of type ', a10)
-139   format(' refinement ratios:       ',6i5,/)  
+139   format(' refinement ratios:       ',6i5,/)
 149   format(' capacity fn. is aux. var',i9)
 
       write(6,*) ' '
       write(6,*) 'Done reading data, starting computation ...  '
       write(6,*) ' '
-
-      globmaxmom = 0. ! initialize values for global max momentum
-      amidoneyet = .False. ! and momentum based stopping criterion.
 
       call outtre (mstart,printout,nvar,naux)
       write(outunit,*) "  original total mass ..."

--- a/amrclaw/2d/lib/amr2ez.f
+++ b/amrclaw/2d/lib/amr2ez.f
@@ -80,6 +80,12 @@ c
       character * 20     parmfile
       character * 25 fname
       logical            vtime,rest
+
+      logical            amidoneyet
+      double precision   globmaxmom
+
+      common /amidone/ amidoneyet,globmaxmom
+
       dimension          tout(maxout)
       dimension          tchk(maxout)
 
@@ -505,6 +511,8 @@ c
       write(6,*) 'Done reading data, starting computation ...  '
       write(6,*) ' '
 
+      globmaxmom = 0. ! initialize values for global max momentum
+      amidoneyet = .False. ! and momentum based stopping criterion.
 
       call outtre (mstart,printout,nvar,naux)
       write(outunit,*) "  original total mass ..."

--- a/amrclaw/2d/lib/amr2ez.f
+++ b/amrclaw/2d/lib/amr2ez.f
@@ -80,7 +80,6 @@ c
       character * 20     parmfile
       character * 25 fname
       logical            vtime,rest
-
       dimension          tout(maxout)
       dimension          tchk(maxout)
 
@@ -107,7 +106,7 @@ c
       open(dbugunit,file=dbugfile,status='unknown',form='formatted')
       open(parmunit,file=parmfile,status='unknown',form='formatted')
 c
-c     ## New in 4.4:
+c     ## New in 4.4:  
 c     ## Open file and skip over leading lines with # comments:
       fname = 'amr2ez.data'
       call opendatafile(inunit,fname)
@@ -146,7 +145,7 @@ c         # ratios in x,y,t from next three lines:
              kratio(i)  = intratx(i)
           enddo
       endif
-
+          
 c      if (intrat(1) .lt. 0) then
 c          # this flags the situation where we do not want to refine in t
 c           write(6,*) '*** No refinement in time!'
@@ -499,12 +498,13 @@ c
      *       ' refinement ratios       ',6i5,/,/)
 119   format(' no. auxiliary vars.     ',i9)
 129   format('       var ',i5,' of type ', a10)
-139   format(' refinement ratios:       ',6i5,/)
+139   format(' refinement ratios:       ',6i5,/)  
 149   format(' capacity fn. is aux. var',i9)
 
       write(6,*) ' '
       write(6,*) 'Done reading data, starting computation ...  '
       write(6,*) ' '
+
 
       call outtre (mstart,printout,nvar,naux)
       write(outunit,*) "  original total mass ..."

--- a/geoclaw/2d/lib/tick_geo.f
+++ b/geoclaw/2d/lib/tick_geo.f
@@ -5,6 +5,7 @@ c
      &                naux,nout,tout,tchk,t0,rest)
 c
       use  geoclaw_module
+      use digclaw_module, only : amidoneyet,globmaxmom
 
       implicit double precision (a-h,o-z)
 
@@ -15,10 +16,6 @@ c
       dimension tout(nout)
       dimension tchk(maxout)
 
-      logical            amidoneyet
-      double precision   globmaxmom
-
-      common /amidone/ amidoneyet,globmaxmom
 c
 c :::::::::::::::::::::::::::: TICK :::::::::::::::::::::::::::::
 c  main driver routine.  controls:

--- a/geoclaw/2d/lib/tick_geo.f
+++ b/geoclaw/2d/lib/tick_geo.f
@@ -15,6 +15,10 @@ c
       dimension tout(nout)
       dimension tchk(maxout)
 
+      logical            amidoneyet
+      double precision   globmaxmom
+
+      common /amidone/ amidoneyet,globmaxmom
 c
 c :::::::::::::::::::::::::::: TICK :::::::::::::::::::::::::::::
 c  main driver routine.  controls:
@@ -308,6 +312,13 @@ c
        if ((mod(ncycle,iout).eq.0) .or. dumpout) then
          call valout(1,lfine,time,nvar,naux)
          if (printout) call outtre(mstart,.true.,nvar,naux)
+
+         ! check whether simulation should be halted.
+         if (amidoneyet) then ! if end time based on momentum.
+           time = tfinal ! set time as time final.
+           ncycle = nstop  ! set number of cycles as max
+           goto 999 ! go to end of time look.
+         endif
        endif
 
       if ( .not. vtime) go to 201

--- a/geoclaw/2d/lib/valout_geo.f
+++ b/geoclaw/2d/lib/valout_geo.f
@@ -3,6 +3,7 @@ c -----------------------------------------------------
 c
       subroutine valout (lst, lend, time, nvar, naux)
 c
+c      from digclaw_module use rho_f,rho_s
       implicit double precision (a-h,o-z)
       character*10  matname1, matname2, matname3
       double precision :: locmaxmom
@@ -97,7 +98,7 @@ c  old        ycorn = rnode(cornylo,mptr) - .5d0*hyposs(level)
                 momvel = (  (alloc(iadd(i,j,2))/momh)**2.
      &                    + (alloc(iadd(i,j,3))/momh)**2.)**0.5
                 momm = alloc(iadd(i,j,4)) / momh
-                momrho = (2700. * momm) + ((1.-momm) * 1000.)
+                momrho = (rho_s * momm) + ((1.-momm) * rho_f)
                 ! hard code values for sediment and fluid density, but
                 ! better than nothing and prob approx right.
                 locmaxmom = locmaxmom ! momentum = (mass * velocity) = density * volume * velocity.

--- a/geoclaw/2d/lib/valout_geo.f
+++ b/geoclaw/2d/lib/valout_geo.f
@@ -50,10 +50,12 @@ c        ###  make the file names and open output files
          if (mom_autostop .eqv. .TRUE.) then
            locmaxmom = 0. ! initialize local max momentum as zero. if
            ! using mom_autostop
+
+
+          write(6,47) locmaxmom, globmaxmom
+47        format('GeoClaw: Starting momentum calc ', d12.6, " ", d12.6)
          endif
 
-         write(6,47) locmaxmom, globmaxmom
-47       format('GeoClaw: Starting momentum calc ', d12.6, " ", d12.6)
          ngrids = 0
  65      if (level .gt. lfine) go to 90
             mptr = lstart(level)

--- a/geoclaw/2d/lib/valout_geo.f
+++ b/geoclaw/2d/lib/valout_geo.f
@@ -47,7 +47,7 @@ c        ###  make the file names and open output files
      .       form='formatted')
 
          level = lst
-         if (mom_autostop) then
+         if (mom_autostop .eqv. .TRUE.) then
            locmaxmom = 0. ! initialize local max momentum as zero. if
            ! using mom_autostop
          endif
@@ -90,7 +90,7 @@ c  old        ycorn = rnode(cornylo,mptr) - .5d0*hyposs(level)
                   alloc(iadd(i,j,ivar)) = 0.d0
                endif
             enddo
-            if (mom_autostop) then
+            if (mom_autostop .eqv. .TRUE.) then
               if (level .eq. lst ) then
                 ! calculate and add to momentum to get a level one momentum sum.
                 momh = alloc(iadd(i,j,1))
@@ -127,7 +127,7 @@ c  old        ycorn = rnode(cornylo,mptr) - .5d0*hyposs(level)
         ! If using mom_autostop then make calculations.
         ! local step_max. if in excess of mom_perc of total max change amidoneyet.
         ! set max to new max.
-        if (mom_autostop) then
+        if (mom_autostop .eqv. .TRUE.) then
           ! if current max is largest, increase the global max
           if (locmaxmom .gt. globmaxmom) then
             globmaxmom = locmaxmom

--- a/geoclaw/2d/lib_dig/digclaw_mod.f90
+++ b/geoclaw/2d/lib_dig/digclaw_mod.f90
@@ -22,8 +22,11 @@ module digclaw_module
     ! ========================================================================
     double precision :: rho_s,rho_f,phi_bed,theta_input,delta,kappita
     double precision :: mu,alpha,m_crit,c1,m0,alpha_seg,sigma_0,phi_seg_coeff,entrainment_rate
-    double precision :: mom_perc,globmaxmom
-    logical :: mom_autostop,amidoneyet
+    double precision :: mom_perc
+    logical :: mom_autostop
+
+    double precision :: globmaxmom = 0. ! initialize values for global max momentum
+    logical :: amidoneyet = .False. ! and momentum based stopping criterion.
 
     integer :: init_ptype,p_initialized,bed_normal,entrainment
     double precision :: init_pmax_ratio,init_ptf2,init_ptf,init_pmin_ratio
@@ -125,10 +128,6 @@ contains
          write(DIG_PARM_UNIT,*) '    entrainment_rate:', entrainment_rate
          write(DIG_PARM_UNIT,*) '    mom_autostop:', mom_autostop
          write(DIG_PARM_UNIT,*) '    mom_perc:', mom_perc
-
-
-         globmaxmom = 0. ! initialize values for global max momentum
-         amidoneyet = .False. ! and momentum based stopping criterion.
 
    end subroutine set_dig
 

--- a/geoclaw/2d/lib_dig/digclaw_mod.f90
+++ b/geoclaw/2d/lib_dig/digclaw_mod.f90
@@ -22,6 +22,8 @@ module digclaw_module
     ! ========================================================================
     double precision :: rho_s,rho_f,phi_bed,theta_input,delta,kappita
     double precision :: mu,alpha,m_crit,c1,m0,alpha_seg,sigma_0,phi_seg_coeff,entrainment_rate
+    double precision :: mom_perc,globmaxmom
+    logical :: mom_autostop,amidoneyet
 
     integer :: init_ptype,p_initialized,bed_normal,entrainment
     double precision :: init_pmax_ratio,init_ptf2,init_ptf,init_pmin_ratio
@@ -35,7 +37,6 @@ module digclaw_module
     integer, parameter ::  i_taudir_x = i_dig + 4
     integer, parameter ::  i_taudir_y = i_dig + 5
     integer, parameter ::  DIG_PARM_UNIT = 78
-
 
 contains
 
@@ -93,6 +94,8 @@ contains
          read(iunit,*) phi_seg_coeff
          read(iunit,*) entrainment
          read(iunit,*) entrainment_rate
+         read(iunit,*) mom_autostop
+         read(iunit,*) mom_perc
 
          close(iunit)
          alpha_seg = 1.0 - alpha_seg
@@ -120,7 +123,12 @@ contains
          write(DIG_PARM_UNIT,*) '    phi_seg_coeff:', phi_seg_coeff
          write(DIG_PARM_UNIT,*) '    entrainment:', entrainment
          write(DIG_PARM_UNIT,*) '    entrainment_rate:', entrainment_rate
+         write(DIG_PARM_UNIT,*) '    mom_autostop:', mom_autostop
+         write(DIG_PARM_UNIT,*) '    mom_perc:', mom_perc
 
+
+         globmaxmom = 0. ! initialize values for global max momentum
+         amidoneyet = .False. ! and momentum based stopping criterion.
 
    end subroutine set_dig
 
@@ -357,7 +365,7 @@ contains
       else
          D = 0.d0
       endif
-      
+
       tanphi = dtan(phi_bed + datan(tanpsi))! + phi_seg_coeff*pmtanh01*dtan(phi_bed)
       !if (S.gt.0.0) then
       !   tanphi = tanphi + 0.38*mu*shear/(shear + 0.005*sigbedc)
@@ -459,7 +467,7 @@ subroutine calc_taudir(maxmx,maxmy,meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux
 
       do i=2-mbc,mx+mbc-1
          do j=2-mbc,my+mbc-1
-            
+
 
             h = q(i,j,1)
             hu = q(i,j,2)
@@ -554,7 +562,7 @@ subroutine calc_taudir(maxmx,maxmy,meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux
             call auxeval(hR,uR,vR,mR,pR,phi,theta,kappa,S,rhoR,tanpsi,D,tauR,sigbed,kperm,compress,pm)
             call auxeval(hB,uB,vB,mB,pB,phi,theta,kappa,S,rhoB,tanpsi,D,tauB,sigbed,kperm,compress,pm)
             call auxeval(hT,uT,vT,mT,pT,phi,theta,kappa,S,rhoT,tanpsi,D,tauT,sigbed,kperm,compress,pm)
-            
+
             !minmod gradients
             FxC = -gmod*h*(EtaR-EtaL)/(2.0*dx) + gmod*h*sin(theta)
             FyC = -gmod*h*(EtaT-EtaB)/(2.0*dy)
@@ -576,12 +584,12 @@ subroutine calc_taudir(maxmx,maxmy,meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux
             else
                Fy = 0.0
             endif
-            
+
             vnorm = sqrt(hu**2 + hv**2)
             if (vnorm>0.0) then
                aux(i,j,i_taudir_x) = -hu/sqrt(hv**2+hu**2)
-               aux(i,j,i_taudir_y) = -hv/sqrt(hv**2+hu**2) 
-               
+               aux(i,j,i_taudir_y) = -hv/sqrt(hv**2+hu**2)
+
                dot = min(max(0.0,Fx*hu) , max(0.0,Fy*hv))
                if (dot>0.0) then
                   !friction should oppose direction of velocity
@@ -597,9 +605,9 @@ subroutine calc_taudir(maxmx,maxmy,meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux
                   !no splitting, integrate friction in src
                   aux(i,j,i_fsphi) = 0.0
                endif
-               
 
-            else 
+
+            else
                !aux now have cell edge interpretation in Riemann solver
                !friction should oppose net force. resolve in Riemann solver
                if ((FxL**2+Fy**2)>0.0) then
@@ -609,9 +617,9 @@ subroutine calc_taudir(maxmx,maxmy,meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux
                endif
 
                if ((Fx**2+FyL**2)>0.0) then
-                  aux(i,j,i_taudir_y) = -FyL/sqrt(Fx**2+FyL**2) 
+                  aux(i,j,i_taudir_y) = -FyL/sqrt(Fx**2+FyL**2)
                else
-                  !there is no motion or net force. resolve in src after Riemann 
+                  !there is no motion or net force. resolve in src after Riemann
                   aux(i,j,i_taudir_y) = 1.0
                endif
 
@@ -619,8 +627,8 @@ subroutine calc_taudir(maxmx,maxmy,meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux
                   aux(i,j,i_fsphi) = 1.0
                else
                   aux(i,j,i_fsphi) = 0.0
-               endif               
-            endif 
+               endif
+            endif
 
          enddo
       enddo
@@ -911,7 +919,7 @@ subroutine calc_pmtanh(pm,seg,pmtanh)
       double precision, intent(out) :: pmtanh
 
       !Locals
-      
+
 
       pmtanh = seg*(0.5*(tanh(40.0*(pm-0.90))+1.0))
       !pmtanh = 0.8*seg*(0.5*(tanh(40.0*(pm-0.98))+1.0))

--- a/python/pyclaw/data.py
+++ b/python/pyclaw/data.py
@@ -1547,6 +1547,9 @@ class DigclawInputData(Data):
         self.add_attribute("entrainment", 0, "flag for entrainment, 0 = no entrainment")
         self.add_attribute("entrainment_rate", 0.2, "rate of entrainment parameter 0-1")
 
+        self.add_attribute("mom_autostop", False, "flag for momentum autostop F = no autostop, T = autostop")
+        self.add_attribute("mom_perc", 0.05, "percentage of max momentum for autostop, default is 0.05 (5%)")
+
     def write(self):
 
         print("Creating data file setdig.data")
@@ -1584,7 +1587,11 @@ class DigclawInputData(Data):
         data_write(
             file, self, "entrainment", "flag for entrainment, 0 = no entrainment"
         )
+
         data_write(file, self, "entrainment_rate", "rate of entrainment parameter 0-1")
+        data_write(file, self, "mom_autostop", "flag for momentum autostop F = no autostop, T = autostop")
+        data_write(file, self, "mom_perc", "percentage of max momentum for autostop, default is 0.05 (5%)")
+
         file.close()
 
         print("Creating data file setpinit.data")


### PR DESCRIPTION
@dlgeorge here's my first attempt at adding an auto-stop capability. Few things of note:
- Its hard coded to consider momentum (rather than some other quantitity).
- The threshold for stopping is when current moving momentum at an output step is below 5% of the maximum momentum. This is probably a reasonable starting place. For example it runs the flume gate release to 21 seconds while your code initially had it end at 20 seconds. 
- It only considers momentum calculated at grid level 1, and only in cells with thickness > 0.0001. 

In order to do make this work I found I needed to declare two global variables and a common block. Maybe I did this in the right place? Maybe not... Anyway, I'd love any input you have. 

There are probably other ways this could be improved (e.g., assess not in valout_geo.f, but in some other routine, assess not on the output timeframes, etc). But I think this is a pretty good start (and the core code is now there). 

(tag @rypjones)
